### PR TITLE
Parse using "parse-sass-value" instead of JSON.stringify

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const PLUGIN_NAME = 'gulp-sass-variables';
 
 let gutil = require('gulp-util'),
+    parse = require('parse-sass-value'),
     PluginError = gutil.PluginError,
     through = require('through2');
 
@@ -10,7 +11,7 @@ let getVariablesBuffer = function(sassVariables, file) {
   let str = '';
   
   for(let variable in sassVariables) {
-    str += variable + ': ' + JSON.stringify(sassVariables[variable]) + ';\n';
+    str += variable + ': ' + parse(sassVariables[variable], { quote: 'double' }) + ';\n';
   }
 
   return new Buffer(str, file);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sass-variables",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Define Sass variables in your gulp task",
   "main": "index.js",
   "scripts": {
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.7",
+    "parse-sass-value": "^2.1.0",
     "through2": "^2.0.1"
   }
 }


### PR DESCRIPTION
I've created `parse-sass-value` module to parse JavaScript values, including objects & arrays, to SASS values. It also handle colors and CSS lengths as primitive values instead of string.

Now, this
```js
variables({
  'title-size': '12px',
  'title-family': [ 'Roboto', 'sans-serif' ],
  'title-line': 1.5,
  'button-theme': {
    size: '300px',
    dark: true
  }
})
```
will be parsed into
```scss
$title-size: 12px;
$title-family: ( 'Roboto', 'sans-serif');
$title-line: 1.5;
$button-theme: (
  'size': 300px,
  'dark': true
);
```