### PR TITLE
supports both sass syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,10 @@ const through = require('through2');
 
 const getVariablesBuffer = function(sassVariables, file) {
   let str = '';
+  let strEndLine = file.extname === '.sass' ? '\n' : ';\n';
   
   for(let variable in sassVariables) {
-    str += variable + ': ' + JSON.stringify(sassVariables[variable]) + ';\n';
+    str += variable + ': ' + JSON.stringify(sassVariables[variable]) + strEndLine;
   }
 
   return new Buffer(str, file);


### PR DESCRIPTION
Hello there,

after updating to gulp-sass v5 I got syntax errors on `.sass` files, this fix it.